### PR TITLE
Ignore messages that are too short

### DIFF
--- a/app/controllers/listener/lines_controller.rb
+++ b/app/controllers/listener/lines_controller.rb
@@ -12,6 +12,7 @@ class Listener::LinesController < ApplicationController
   private
 
   def forwardable?(rumor)
+    return false unless rumor
     rumor.length > 20
   end
 
@@ -36,7 +37,7 @@ class Listener::LinesController < ApplicationController
     reply_token = event['replyToken']
     rumor       = event['message']['text']
 
-    ReplyWorker.perform_async(reply_token, rumor) if rumor && forwardable?(rumor)
+    ReplyWorker.perform_async(reply_token, rumor) if forwardable?(rumor)
   end
 
   def introduce(event)

--- a/app/controllers/listener/lines_controller.rb
+++ b/app/controllers/listener/lines_controller.rb
@@ -11,6 +11,10 @@ class Listener::LinesController < ApplicationController
 
   private
 
+  def forwardable?(rumor)
+    rumor.length > 20
+  end
+
   def event
     @uniq_event_tokens = params['events'].map { |e| e['replyToken'] }.uniq
     @events = params['events'].select { |e| @uniq_event_tokens.include?(e['replyToken']) }
@@ -32,7 +36,7 @@ class Listener::LinesController < ApplicationController
     reply_token = event['replyToken']
     rumor       = event['message']['text']
 
-    ReplyWorker.perform_async(reply_token, rumor) if rumor
+    ReplyWorker.perform_async(reply_token, rumor) if rumor && forwardable?(rumor)
   end
 
   def introduce(event)

--- a/spec/controllers/listener/lines_controller_spec.rb
+++ b/spec/controllers/listener/lines_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Listener::LinesController, type: :controller do
     let(:payload) do
       {
         "events": [
-          {
+          { # This message is not forwarded message, should ignore
             "replyToken": "00000000000000000000000000000000",
             "type": "message",
             "timestamp": 1545406547368,
@@ -17,6 +17,21 @@ RSpec.describe Listener::LinesController, type: :controller do
               "id": "100001",
               "type": "text",
               "text": "Hello, world",
+            },
+          },
+          { # This message is a forwarded message, should perform
+            "replyToken": "00000000000000000000000000000001",
+            "type": "message",
+            "timestamp": 1545406547368,
+            "source": {
+              "type": "user",
+              "userId": "Udeadbeefdeadbeefdeadbeefdeadbeef",
+            },
+            "message": {
+              "id": "100001",
+              "type": "text",
+
+              "text": "剛剛美國🇺🇸紐約皇后區發生商業街大爆炸事件。\n又一次911。美國的電視已經在報道。",
             },
           },
           {
@@ -52,7 +67,8 @@ RSpec.describe Listener::LinesController, type: :controller do
     end
 
     it 'should assign ReplyWorker' do
-      expect(ReplyWorker).to receive(:perform_async).with("00000000000000000000000000000000", "Hello, world").once
+      expect(ReplyWorker).not_to receive(:perform_async).with("00000000000000000000000000000000", "Hello, world")
+      expect(ReplyWorker).to receive(:perform_async).with("00000000000000000000000000000001", "剛剛美國🇺🇸紐約皇后區發生商業街大爆炸事件。\n又一次911。美國的電視已經在報道。").once
       post :check, params: payload
     end
 


### PR DESCRIPTION
Chatroom messages are often comprised of short messages.

According to [previous analysis](https://docs.google.com/spreadsheets/d/1AN0YNiUWdkrOXT6NNfDvTMKpUpLTs9BF_LkABs1GZX8/edit#gid=1958593018) and [discussions](https://g0v.hackmd.io/s/HyK5rsQiX#%E8%A7%A3%E7%A6%81-URL), almost all messages < 20 characters are conversation rather than forwarded messages (轉傳訊息) that needs to be checked.

This PR prevents messages that are not "forwarded messages" being sent to Cofacts API server. This reduces the load of Cofacts API server, as well as reduce the queue length of this project as well.

Note: I edited the file on Github, did not test on machines.